### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/christiewd.js
+++ b/christiewd.js
@@ -102,12 +102,12 @@ instance.prototype.init_tcp = function() {
 		self.socket.on("iac", function(type, info) {
 			// tell remote we WONT do anything we're asked to DO
 			if (type == 'DO') {
-				socket.write(new Buffer([ 255, 252, info ]));
+				socket.write(Buffer.from([ 255, 252, info ]));
 			}
 
 			// tell the remote DONT do whatever they WILL offer
 			if (type == 'WILL') {
-				socket.write(new Buffer([ 255, 254, info ]));
+				socket.write(Buffer.from([ 255, 254, info ]));
 			}
 		});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "christie-wd",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"legacy": ["christiewd"],
 	"api_version": "1.0.0",
 	"keywords": [


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/